### PR TITLE
Feedback

### DIFF
--- a/feedback/env-anywhere-def.R
+++ b/feedback/env-anywhere-def.R
@@ -1,0 +1,25 @@
+#' which parent environments of <env> contain <name>?
+#' inputs:
+#'    name: a variable name
+#'    env: valid inputs for pryr:::to_env, defaults to the calling frame
+#' output: a list of environments containing <name>
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name, min.chars = 1)
+  #to_env takes care of checks for <env> and conversions to environments
+  # (input checking & homogenization)
+  env <- pryr:::to_env(env)
+
+  result <- list()
+  # base case: terminate recursion in emptyenv and return empty list
+  if (identical(env, emptyenv())) {
+    return(list())
+  }
+  # success: if <name> is in current <env>, <env> is added to results list ...
+  if (exists(name, env, inherits = FALSE)) {
+    result <- append(result, env)
+  }
+  # .... and then we go up one level to the next environment and add what we
+  #      find there to the list
+  # (recursion)
+  append(result, anywhere(name, parent.env(env)))
+}

--- a/feedback/env-sol.Rmd
+++ b/feedback/env-sol.Rmd
@@ -1,0 +1,56 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+```{r, child = "env-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a) 
+
+* alle Objekte in `environment` müssen Namen haben, Listen können unbenamte Einträge haben.
+* Objekte in einem `environment` haben keine Reihenfolge/Topologie, Einträge in einer Liste schon.
+* Jedes `environment` hat eine Elternumgebung
+* `environment`s haben *reference semantics*: D.h. das im `environment` hinterlegte *binding* eines Symbols (also: des Namens einer Variable) an einen Wert wird nur über den Speicherort dieses Werts repräsentiert (also: ein bestimmtes Symbol verweist auf -- *referenziert* -- eine Adresse im Speicher). Das heißt:
+    - ein und das selbe Objekt/der selbe Wert kann Element mehrer `environments` sein, unter möglicherweise unterschiedlichen Namen die aber eben alle den selben Speicherort referenzieren! 
+    - Modifikation eines `environment` erzeugt keine Kopie der im `environment` an Symbole gebundenen Werte (also: kein *copy-on-modify* wie bei anderen R Objekten).
+
+b) 
+
+In der Umgebung aus der sie aufgerufen wurden, siehe `?ls` bzw. `?rm`.
+
+c) 
+
+Siehe `help("<-"), help("<<-")`. 
+
+`<-` legt eine neue `binding` (eine Verknüpfung zwischen einem Symbol für eine Variable und dem Speicherort wo der Wert der Variable ) in der Umgebung in der `<-` aufgerufen wurde an, bzw. ersetzt eine alte Zuweisung für die Variable auf der linken Seite. 
+
+Das Verhalten von `<<-` hängt davon ab ob/wo eine Variable durch das Symbol auf der linken Seite bereits definiert ist. Falls die Variable in der aufrufenden Umgebung nicht definiert ist, sucht `<<-` die Vorfahrenumgebungen der aufrufenden Umgebung ab und ersetzt die Zuweisung in der ersten Vorfahrenumgebung in der die Variable definiert ist. Ist sie nirgends definiert (oder bereits bestehende `binding`s sind `locked`, also nicht überschreibbar) so wird eine neue Variable im `.GlobalEnv` angelegt.
+
+d)
+
+Mit Rekursion (Funktion `anywhere()` ruft sich immer wieder selbst auf):
+```{r, def_anywhere, code = readLines("env-anywhere-def.R"), echo = FALSE}
+```
+Äquivalent ohne Rekursion:
+```{r, def_anywhere_sequential, eval=FALSE}
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name)
+  env <- pryr:::to_env(env)
+  result <- list()
+  while (!identical(env, emptyenv())) {
+    if (exists(name, env, inherits = FALSE)) {
+      result <- append(result, env)
+    }
+    env <- parent.env(env)
+  }
+  result
+}
+```
+
+```{r, test-anywhere, eval = TRUE, code=readLines("test-env-anywhere.R")}
+```
+Sie fragen vielleicht warum hier auch eine Variable "`t`" gefunden wird, die in der Umgebung, die mit dem `base`-Paket assoziiert ist, liegt...? Da haben wir doch gar nix angelegt...? Das ist die Funktion mit der Matrizen und Vektoren transponiert werden! 


### PR DESCRIPTION
@jaeeun-n 

naja, das mit der d) war nix.
können sie denke ich besser, nächstes mal dann wieder... 

--------------------------------------------------------------------

- Textantworten zu b) c) relativ knapp, bitte nochmal mit Musterlösung vergleichen ob Ihnen alle Nuancen hier gegenwärtig waren.

- Funktion `where_path` ist falsch implementiert und besteht auch nicht die mitgelieferten tests -- wenn ich ihre funktion in `anywhere` umbenenne kriege ich:
```r
> test_file("ex/env/test-env-anywhere.R")

══ Testing test-env-anywhere.R ═══════════════════════════════════════════════════════════════════════
[ FAIL 2 | WARN 0 | SKIP 0 | PASS 0 ]

── Error (test-env-anywhere.R:14:3): anywhere has basic functionality ────────────────────────────────
Error: 'names' attribute [3] must be the same length as the vector [1]
Backtrace:
 1. testthat::expect_is(test1 <- anywhere("t", env = e0), "list") test-env-anywhere.R:14:2
 4. global::anywhere("t", env = e0)

── Error (test-env-anywhere.R:29:3): anywhere deals with errors & failures ───────────────────────────
Error: Can't find nothing_found
Backtrace:
 1. testthat::expect_identical(...) test-env-anywhere.R:29:2
 4. global::anywhere("nothing_found", env = emptyenv())
> # genauer
> anywhere("t", env = e0)
Error in names(env_path) <- c(paste("child", length(children):1, sep = "_"),  : 
  'names' attribute [3] must be the same length as the vector [1]
```
bitte in zukunft diese unit tests auch wirklich benutzen..... :roll_eyes: 

- für mich nicht wirklich nachvollziehbar was in L. 39 - L47 passiert, sorry. Vgl Musterlösung 

- https://github.com/fort-w2021/env-ex-jaeeun-n/blob/5266c9ffdfc5d01a1c67b1ef75069182fc15563a/env-ex-sol.Rmd#L32
  1. bitte immer kommentar mit zweck, inputs, output der funktion über jeder funktionsdefinition
  2. bitte unbedingt immer an aufgaben-spezifikation halten -- gefragt war funktion `anywhere()` nicht `where_path()`

- https://github.com/fort-w2021/env-ex-jaeeun-n/blob/5266c9ffdfc5d01a1c67b1ef75069182fc15563a/env-ex-sol.Rmd#L34
besser mit `assert_string`. muss außerdem auch non-NA, non-empty sein.

- https://github.com/fort-w2021/env-ex-jaeeun-n/blob/5266c9ffdfc5d01a1c67b1ef75069182fc15563a/env-ex-sol.Rmd#L37
nö. wie in den units tests spezifiziert soll das in dem fall ne leere liste zurückgeben.... 

- https://github.com/fort-w2021/env-ex-jaeeun-n/blob/5266c9ffdfc5d01a1c67b1ef75069182fc15563a/env-ex-sol.Rmd#L44-L45
`else` wo möglich komplett vermeiden, wenn schon dann aber bitte `else {` in die  selbe Zeile wie die schließende Klammer des dazugehörenden `if` Blocks
